### PR TITLE
fix: #4 move theme switcher to top navbar on mobile

### DIFF
--- a/src/app/companies/CompaniesTimeline.tsx
+++ b/src/app/companies/CompaniesTimeline.tsx
@@ -13,9 +13,12 @@ const accentColors = [
   { dot: '#5F5E5A', bg: '#F1EFE8' },
 ];
 
-export default function CompaniesTimeline() {
+export default function CompaniesTimeline({ isTablet }: { isTablet: boolean }) {
   return (
-    <div className={styles.timeline}>
+    <div
+      className={styles.timeline}
+      style={isTablet ? { paddingTop: '72px', paddingLeft: '1rem', paddingRight: '1rem', maxWidth: '100%', boxSizing: 'border-box' } : undefined}
+    >
       {experienceData.map((job, index) => {
         const isCurrent = !job.to;
         const dateRange = isCurrent ? `${job.from} — Present` : `${job.from} — ${job.to}`;

--- a/src/app/companies/ct.module.css
+++ b/src/app/companies/ct.module.css
@@ -1,12 +1,13 @@
 .timeline {
-  padding: 2rem 1rem 2rem 1.5rem;
+  padding: 2rem 1.5rem;
   max-width: 960px;
-  margin: 0 auto;
+  margin-right: auto;
   width: 100%;
 }
 .row {
   display: grid;
-  grid-template-columns: 1fr 48px 1fr;
+  grid-template-columns: 1fr 40px 1fr;
+  min-width: 0;
 }
 .center {
   display: flex;

--- a/src/app/companies/page.tsx
+++ b/src/app/companies/page.tsx
@@ -5,11 +5,11 @@ import CompaniesTimeline from './CompaniesTimeline';
 import CompaniesTimelineMobile from './CompaniesTimelineMobile';
 
 export default function CompaniesPage() {
-  const { isMobile } = useResponsive();
+  const { isMobile, isTablet } = useResponsive();
 
   return (
     <div className="container">
-      {isMobile ? <CompaniesTimelineMobile /> : <CompaniesTimeline />}
+      {isMobile ? <CompaniesTimelineMobile /> : <CompaniesTimeline isTablet={isTablet} />}
     </div>
   );
 }

--- a/src/components/Navbar.scss
+++ b/src/components/Navbar.scss
@@ -91,11 +91,12 @@ $bg2-color: hsl(var(--bg2));
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 0 24px 0 0px;
-
     .links-div { display: none; }
 
+    .links-div-logo { flex: 0 0 auto; }
+
     .hamburger-icon {
+      flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/components/ThemeSwitcherMobile.module.css
+++ b/src/components/ThemeSwitcherMobile.module.css
@@ -6,8 +6,15 @@
   gap: 12px;
   width: 100%;
   padding: 12px 0 0;
-  border-top: 1px solid hsl(var(--txt) / 0.1);
   margin-top: 8px;
+}
+.wrapperNav {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
 }
 .btn {
   display: flex;

--- a/src/components/ThemeSwitcherMobile.tsx
+++ b/src/components/ThemeSwitcherMobile.tsx
@@ -3,10 +3,12 @@ import DynamicIcon from './DynamicIcon';
 import { useThemeSwitcher } from '@/hooks/useThemeSwitcher';
 import styles from './ThemeSwitcherMobile.module.css';
 
-export default function ThemeSwitcherMobile() {
+interface Props { inNavbar?: boolean; }
+
+export default function ThemeSwitcherMobile({ inNavbar }: Props) {
   const { theme, toggleTheme, DARK, hue, handleHueChange, isColorPicking, setIsColorPicking } = useThemeSwitcher();
   return (
-    <div className={styles.wrapper}>
+    <div className={inNavbar ? styles.wrapperNav : styles.wrapper}>
       <button className={styles.btn} onClick={toggleTheme}>
         <DynamicIcon name={theme === DARK ? 'BsFillCloudMoonFill' : 'BsFillCloudSunFill'} />
       </button>

--- a/src/features/navigation/MobileMenu.tsx
+++ b/src/features/navigation/MobileMenu.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation';
 import { IoHomeOutline, IoBusinessOutline, IoExtensionPuzzleOutline, IoBarChartOutline } from 'react-icons/io5';
 import { MdOutlineContactMail } from 'react-icons/md';
 import { AiOutlineClose } from 'react-icons/ai';
-import ThemeSwitcherMobile from '@/components/ThemeSwitcherMobile';
 import styles from './MobileMenu.module.css';
 
 const routes = [
@@ -49,7 +48,6 @@ export default function MobileMenu({ isOpen, onClose }: Props) {
             );
           })}
         </nav>
-        <ThemeSwitcherMobile />
       </div>
     </>
   );

--- a/src/features/navigation/Navbar.tsx
+++ b/src/features/navigation/Navbar.tsx
@@ -7,11 +7,12 @@ import NavLinks from './NavLinks';
 import MobileMenu from './MobileMenu';
 import ThemeSwitcherWeb from '@/components/ThemeSwitcherWeb';
 import ThemeSwitcherTablet from '@/components/ThemeSwitcherTablet';
+import ThemeSwitcherMobile from '@/components/ThemeSwitcherMobile';
 import '@/components/Navbar.scss';
 
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { isDesktop, isTablet } = useResponsive();
+  const { isDesktop, isTablet, isMobile } = useResponsive();
 
   return (
     <div className="nav-bar">
@@ -31,10 +32,13 @@ export default function Navbar() {
         </>
       )}
 
-      {!isDesktop && !isTablet && (
-        <button className="flat-button hamburger-icon" onClick={() => setIsMenuOpen(true)}>
-          <FaBars />
-        </button>
+      {isMobile && (
+        <>
+          <ThemeSwitcherMobile inNavbar={true} />
+          <button className="flat-button hamburger-icon" onClick={() => setIsMenuOpen(true)}>
+            <FaBars />
+          </button>
+        </>
       )}
 
       <MobileMenu isOpen={isMenuOpen} onClose={() => setIsMenuOpen(false)} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -247,6 +247,7 @@ textarea {
   opacity: 0;
   margin: 0 auto;
   padding-left: 72px;
+  box-sizing: border-box;
   z-index: 1;
   transform-style: preserve-3d;
   animation: fadeIn 1s forwards;


### PR DESCRIPTION
Fixes #4

## Changes
- Removed ThemeSwitcherMobile from MobileMenu panel
- Added ThemeSwitcherMobile to Navbar between SV logo and hamburger on mobile
- Added inNavbar prop to ThemeSwitcherMobile to strip panel-specific styles (border-top, padding)
- Used isMobile from useResponsive hook explicitly in Navbar
- Removed padding from mobile .nav-bar in Navbar.scss

## Screenshots
- Theme icons now visible in top nav at all times on mobile
- Mobile menu panel is clean with no icons at bottom